### PR TITLE
#3 Addition of ifconfig

### DIFF
--- a/view/frontend/layout/customer_account_create.xml
+++ b/view/frontend/layout/customer_account_create.xml
@@ -11,7 +11,7 @@
         <referenceContainer name="content">
             <referenceBlock class="Magento\Customer\Block\Form\Register" name="customer_form_register"
                             template="Magento_Customer::form/register.phtml">
-                <action method="setTemplate">
+                <action ifconfig="hoodoor/general/enable_frontend" method="setTemplate">
                     <argument name="template" xsi:type="helper"
                               helper="Opengento\Hoodoor\Model\Template\Manager::getTemplate">
                         <param name="default">Magento_Customer::form/register.phtml</param>

--- a/view/frontend/layout/customer_account_edit.xml
+++ b/view/frontend/layout/customer_account_edit.xml
@@ -10,7 +10,7 @@
     <body>
         <referenceContainer name="content">
             <referenceBlock name="customer_edit" template="Opengento_Hoodoor::form/edit.phtml">
-                <action method="setTemplate">
+                <action ifconfig="hoodoor/general/enable_frontend" method="setTemplate">
                     <argument name="template" xsi:type="helper"
                               helper="Opengento\Hoodoor\Model\Template\Manager::getTemplate">
                         <param name="default">Magento_Backend::form/edit.phtml</param>

--- a/view/frontend/layout/customer_account_index.xml
+++ b/view/frontend/layout/customer_account_index.xml
@@ -10,7 +10,7 @@
     <body>
         <referenceContainer name="content">
             <referenceBlock name="customer_account_dashboard_info">
-                <action method="setTemplate">
+                <action ifconfig="hoodoor/general/enable_frontend" method="setTemplate">
                     <argument name="template" xsi:type="helper"
                               helper="Opengento\Hoodoor\Model\Template\Manager::getTemplate">
                         <param name="default">Magento_Customer::account/dashboard/info.phtml</param>

--- a/view/frontend/layout/customer_account_login.xml
+++ b/view/frontend/layout/customer_account_login.xml
@@ -10,7 +10,7 @@
     <body>
         <referenceContainer name="content">
             <referenceBlock name="customer_form_login">
-                <action method="setTemplate">
+                <action ifconfig="hoodoor/general/enable_frontend" method="setTemplate">
                     <argument name="template" xsi:type="helper"
                               helper="Opengento\Hoodoor\Model\Template\Manager::getTemplate">
                         <param name="default">Magento_Customer::form/login.phtml</param>


### PR DESCRIPTION
Related to https://github.com/opengento/magento2-hoodoor/issues/3

Adding config only to the frontend customer templates layouts to avoid resetting values to base value if the module is not enabled.

This avoids resetting templates if some other overrides are done elsewhere.